### PR TITLE
Docker registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Nullstone
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Package files into tgz
+      - name: Package
+        run: tar -cvzf module.tgz *.tf
+
+      - name: Find version
+        id: version
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
+
+      # Publish to nullstone
+      - name: Publish
+        env:
+          NULLSTONE_ORG: nullstone
+          NULLSTONE_MODULE: aws-fargate-service
+          RELEASE_VERSION: ${{ steps.version.outputs.tag }}
+        run: |-
+          curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \
+            https://api.nullstone.io/orgs/${NULLSTONE_ORG}/modules/${NULLSTONE_MODULE}/versions?version=${RELEASE_VERSION}

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,12 +4,17 @@ output "log_group_name" {
 }
 
 output "repo_name" {
-  value       = aws_ecr_repository.this.name
+  value       = try(aws_ecr_repository.this[0].name, "")
   description = "string ||| "
 }
 
 output "repo_url" {
-  value       = aws_ecr_repository.this.repository_url
+  value       = try(aws_ecr_repository.this[0].repository_url, "")
+  description = "string ||| "
+}
+
+output "service_image" {
+  value       = "${local.service_image}:${var.service_image_tag}"
   description = "string ||| "
 }
 

--- a/repository.tf
+++ b/repository.tf
@@ -1,6 +1,14 @@
+locals {
+  // If someone specifies `var.service_image`, the ecr repository will not be created
+  // The following variable sets up the effective docker image
+  service_image = try(aws_ecr_repository.this[0].repository_url, var.service_image)
+}
+
 // This is a bit odd - we're creating a repository for every environment
 // We need to find a better way to do this
 resource "aws_ecr_repository" "this" {
   name = "${data.ns_workspace.this.stack}/${data.ns_workspace.this.env}-${data.ns_workspace.this.block}"
   tags = data.ns_workspace.this.tags
+
+  count = var.service_image == "" ? 1 : 0
 }

--- a/task.tf
+++ b/task.tf
@@ -3,7 +3,7 @@ locals {
 
   container_definition = {
     name  = data.ns_workspace.this.block
-    image = "${aws_ecr_repository.this.repository_url}:${var.service_image_tag}"
+    image = "${local.service_image}:${var.service_image_tag}"
     portMappings = [
       {
         protocol      = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,16 @@ This means the default is 512 MiB or 0.5 GiB.
 EOF
 }
 
+variable "service_image" {
+  type        = string
+  default     = ""
+  description = <<EOF
+The docker image to deploy for this service.
+By default, this is blank, which means that an ECR repo is created and used.
+Use this variable to configure against docker hub, quay, etc.
+EOF
+}
+
 variable "service_image_tag" {
   type        = string
   default     = "latest"


### PR DESCRIPTION
Allowing the Fargate service to use something other than ECR.
For nullstone, this allows us to specify `nullstone/furion` for furion's image on docker hub.