### PR TITLE
Replaced load balancer logs bucket with simple local module

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Package files into tgz
       - name: Package
-        run: tar -cvzf module.tgz *.tf
+        run: tar -cvzf module.tgz *.tf lb_logs/*.tf
 
       - name: Find version
         id: version

--- a/lb_logs/main.tf
+++ b/lb_logs/main.tf
@@ -1,0 +1,80 @@
+data "aws_elb_service_account" "default" {}
+
+data "aws_iam_policy_document" "default" {
+  statement {
+    sid = ""
+
+    principals {
+      type        = "AWS"
+      identifiers = [join("", data.aws_elb_service_account.default.*.arn)]
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "default" {
+  bucket        = local.bucket_name
+  acl           = "log-delivery-write"
+  force_destroy = var.force_destroy
+  policy        = data.aws_iam_policy_document.default.json
+
+  tags = merge({ Name : var.name }, var.tags)
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled                                = true
+    abort_incomplete_multipart_upload_days = 5
+
+    noncurrent_version_expiration {
+      days = 90
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/lb_logs/outputs.tf
+++ b/lb_logs/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_domain_name" {
+  value       = aws_s3_bucket.default.bucket_domain_name
+  description = "FQDN of bucket"
+}
+
+output "bucket_id" {
+  value       = aws_s3_bucket.default.id
+  description = "Bucket Name (aka ID)"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.default.arn
+  description = "Bucket ARN"
+}

--- a/lb_logs/variables.tf
+++ b/lb_logs/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "force_destroy" {
+  type    = bool
+  default = false
+}
+
+resource "random_uuid" "bucket_name" {}
+
+locals {
+  bucket_name = random_uuid.bucket_name.result
+}

--- a/load-balancer.tf
+++ b/load-balancer.tf
@@ -8,7 +8,7 @@ resource "aws_lb" "this" {
   ip_address_type    = "ipv4"
 
   access_logs {
-    bucket  = module.lb_logs_bucket.bucket_id
+    bucket  = module.lb_logs_bucket[count.index].bucket_id
     enabled = true
   }
 

--- a/logs.tf
+++ b/logs.tf
@@ -5,15 +5,11 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 module "lb_logs_bucket" {
-  source  = "cloudposse/lb-s3-bucket/aws"
-  version = "0.7.0"
+  source = "./lb_logs"
 
-  enabled = var.enable_lb
+  count = var.enable_lb ? 1 : 0
 
-  name   = data.ns_workspace.this.hyphenated_name
-  region = data.aws_region.this.name
-
+  name          = data.ns_workspace.this.hyphenated_name
+  tags          = data.ns_workspace.this.tags
   force_destroy = true
-
-  tags = data.ns_workspace.this.tags
 }


### PR DESCRIPTION
This PR introduces our own module for creating load balancer logs bucket.
This allows us to create a globally unique s3 bucket to avoid `BucketAlreadyExists` error.